### PR TITLE
Fix header gap

### DIFF
--- a/sass/_vendor.scss
+++ b/sass/_vendor.scss
@@ -193,6 +193,10 @@ a:hover {
   padding: 0
 }
 
+.hack header + article {
+  margin-top: 20px;
+}
+
 .hack blockquote, .hack h1, .hack ol, .hack p, .hack ul {
   margin-top: 20px;
   margin-bottom: 20px

--- a/templates/page.html
+++ b/templates/page.html
@@ -42,6 +42,8 @@
                     {% endfor %}
                 {% endif %}
             </p>
+            {% block extra_footer %}
+            {% endblock extra_footer %}
         </footer>
     {% endblock page_footer %}
 </article>


### PR DESCRIPTION
Current theme has no gap between first entry and header when used without `after_dark_title`. This fixes gives the first entry a gap to make it look better.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/7413880/87224014-a227b280-c3bc-11ea-8317-c76d17fff35d.png) | ![2](https://user-images.githubusercontent.com/7413880/87224017-aa7fed80-c3bc-11ea-8b89-44e39001e3a0.png) |

