### PR TITLE
feat: add katex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,33 @@ The site title is shown on the homepage. As it might be different from the `<tit
 element that the `title` field in the config represents, you can set the `after_dark_title`
 instead.
 
+### KaTeX math formula support
+
+This theme contains math formula support using [KaTeX](https://katex.org/),
+which can be enabled by setting `katex_enable = true` in the `extra` section
+of `config.toml`:
+
+```toml
+[extra]
+katex_enable = true
+```
+
+After enabling this extension, the `katex` short code can be used in documents:
+* `{{ katex(body="\KaTeX") }}` to typeset a math formula inlined into a text,
+  similar to `$...$` in LaTeX
+* `{% katex(block=true) %}\KaTeX{% end %}` to typeset a block of math formulas,
+  similar to `$$...$$` in LaTeX
+
+#### Automatic rendering without short codes
+
+Optionally, `\\( \KaTeX \\)` inline and `\\[ \KaTeX \\]` / `$$ \KaTeX $$`
+block-style automatic rendering is also supported, if enabled in the config:
+
+```toml
+[extra]
+katex_enable = true
+katex_auto_render = true
+```
+
 ## Original
 This template is based on the Hugo template https://git.habd.as/comfusion/after-dark

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,22 @@
 
       {% block css %}
           <link rel="stylesheet" href="{{ get_url(path="site.css", trailing_slash=false) | safe }}">
+		  {% if config.extra.katex_enable %}
+          <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.css" integrity="sha384-9eLZqc9ds8eNjO3TmqPeYcDj8n+Qfa4nuSiGYa6DjLNcv9BtN69ZIulL9+8CqC9Y" crossorigin="anonymous">
+          {% endif %}
       {% endblock css %}
+
+      {% block js %}
+          {% if config.extra.katex_enable %}
+          <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/katex.min.js" integrity="sha384-K3vbOmF2BtaVai+Qk37uypf7VrgBubhQreNQe9aGsz9lB63dIFiQVlJbr92dw2Lx" crossorigin="anonymous"></script>
+          <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/mathtex-script-type.min.js" integrity="sha384-zWYbd0NBwgTsgIdFKVprSfTh1mbMPe5Hz1X3yY4Sd1h/K1cQoUe36OGwAGz/PcDy" crossorigin="anonymous"></script>
+              {% if config.extra.katex_auto_render %}
+          <script defer src="https://cdn.jsdelivr.net/npm/katex@0.10.0/dist/contrib/auto-render.min.js" integrity="sha384-kmZOZB5ObwgQnS/DuDg6TScgOiWWBiVt0plIRkZCmE6rDZGrEOQeHM5PcHi+nyqe" crossorigin="anonymous"
+                  onload="renderMathInElement(document.body);"></script>
+              {% endif %}
+          {% endif %}
+
+      {% endblock js %}
 
       {% block extra_head %}
       {% endblock extra_head %}

--- a/templates/shortcodes/katex.html
+++ b/templates/shortcodes/katex.html
@@ -1,0 +1,1 @@
+ <script type="math/tex{% if block %};mode=display{% endif %}">{{body}}</script> 


### PR DESCRIPTION
This is mostly copy-paste of https://github.com/getzola/even/pull/16.

I tested it locally, works as expected.

I'm still wondering whether zola can do anything to make this less painful, as porting KaTeX rendering to every theme is quite a lot of duplication. This is okay *now*, but updating will be a major PITA. A solution where zola inserts these would be a lot better IMO.