### PR TITLE
Remove empty space at the bottom of code blocks

### DIFF
--- a/sass/_vendor.scss
+++ b/sass/_vendor.scss
@@ -298,7 +298,7 @@ a:hover {
 }
 
 .hack pre code:after, .hack pre code:before {
-  content: ''
+  content: none
 }
 
 .hack code {


### PR DESCRIPTION
before: 
![2020-10-01_02-08-35_grim](https://user-images.githubusercontent.com/2302947/94752330-389bbc80-038b-11eb-9b35-99d7e91a444f.png)
after:
![2020-10-01_02-09-11_grim](https://user-images.githubusercontent.com/2302947/94752331-39cce980-038b-11eb-904d-820198c08d95.png)

