### PR TITLE
Remove spurious space

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -33,8 +33,7 @@
                             <a itemprop="url"
                                class="{% if item.url | replace(from="$BASE_URL", to=config.base_url) == current_url %}active{% endif %}"
                                href="{{ item.url | safe | replace(from="$BASE_URL", to=config.base_url) }}">
-                                <span itemprop="name">{{ item.name }}
-                                </span></a>
+                                <span itemprop="name">{{ item.name }}</span></a>
                         {% endfor %}
                         </nav>
                     </header>


### PR DESCRIPTION
Removes a spurious space in the generated HTML between links where a `$BASE_URL` is not specified. Links with `$BASE_URL` are not affected because the SVG fixes somehow the problem.

To reproduce, change the `config.toml` as follows:

```diff
diff --git a/config.toml b/config.toml
index 5aeb7ba..6a23067 100644
--- a/config.toml
+++ b/config.toml
@@ -15,5 +15,7 @@ after_dark_menu = [
     {url = "$BASE_URL", name = "Home"},
     {url = "$BASE_URL/categories", name = "Categories"},
     {url = "$BASE_URL/tags", name = "Tags"},
+    {url = "/link", name = "Link"},
+    {url = "/link", name = "Link2"}
 ]
 after_dark_title = "My blog"
```

Before this patch:
![screenshot-20220801-010749](https://user-images.githubusercontent.com/6098822/182049008-e67fbc44-31ce-41f0-af4b-fd5597caa3bf.png)


After this patch:
![screenshot-20220801-010724](https://user-images.githubusercontent.com/6098822/182049018-ad439a4e-4679-4286-bee9-a2746ae13961.png)

thanks for having a look at this