### PR TITLE
Remove redundant CSS formatting on <ol> elements

### DIFF
--- a/sass/_vendor.scss
+++ b/sass/_vendor.scss
@@ -187,7 +187,7 @@ a:hover {
   line-height: 20px
 }
 
-.hack blockquote, .hack code, .hack footer, .hack h1, .hack h2, .hack h3, .hack h4, .hack h5, .hack h6, .hack header, .hack li, .hack ol, .hack p, .hack section, .hack ul {
+.hack blockquote, .hack code, .hack footer, .hack h1, .hack h2, .hack h3, .hack h4, .hack h5, .hack h6, .hack header, .hack li, .hack p, .hack section, .hack ul {
   float: none;
   margin: 0;
   padding: 0
@@ -253,8 +253,6 @@ a:hover {
 
 .hack li {
   position: relative;
-  display: block;
-  padding-left: 20px
 }
 
 .hack li:after {
@@ -265,15 +263,6 @@ a:hover {
 
 .hack ul > li:after {
   content: "-"
-}
-
-.hack ol {
-  counter-reset: a
-}
-
-.hack ol > li:after {
-  content: counter(a) ".";
-  counter-increment: a
 }
 
 .hack blockquote {


### PR DESCRIPTION
With this patch I'm trying to fix some CSS that is applied to the `<ol>` HTML element.

Rendering before this patch
![screenshot-20221010-122905](https://user-images.githubusercontent.com/6098822/194848474-589d7d27-e81d-4429-8ab2-dbed645ce9b6.png)

<details><summary>The HTML rendered by Zola is correct:</summary>

```html
<ol>
<li>First item</li>
<li>Second item (leading spaces ignored)</li>
</ol>
<p>I want to start the following list from an arbitrary number:</p>
<ol start="3">
<li>I want this to be the third item</li>
<li>I want this to be the fourth item</li>
</ol>
```

</details>

But I see two small CSS issues:
- there is no padding between the `<li>` and the text
- the `start` parameter of the `<ol>` element is overriden by the CSS

Rendering after this patch
![screenshot-20221010-122739](https://user-images.githubusercontent.com/6098822/194848512-d71d9fff-ee26-4c83-b852-02112aaf1423.png)

Note: I'm not a CSS wizard so I'm not entirely sure these changes have unintended side-effects. Namely I'd be curious to test them against the markdown from #24 but I could not find the repo of the issue reporter (they have also changed Zola theme in the meanwhile...)


@Keats opinions? thanks :)