### PR TITLE
update base_url to fix Netlify Redirect

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://zola-after-dark.netlify.com"
+base_url = "https://zola-after-dark.netlify.app"
 compile_sass = true
 title = "after-dark theme"
 description = "A robust, elegant dark theme"


### PR DESCRIPTION
It seems Netlify is redirecting all of the .com to .app  This is affecting the demo, every link redirects from .com to .app

You can see yourself by navigating pages on the current demo:  https://zola-after-dark.netlify.com

I noticed this is an issue with adidoks as well, and  couple other themes, so I will submit pull requests to the others as well.