### PR TITLE
Add netlify.toml Headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,13 @@
 
 [context.deploy-preview]
     command = "zola build --base-url $DEPLOY_PRIME_URL"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Strict-Transport-Security = "max-age=63072000; includeSubdomains"
+    Content-Security-Policy = "default-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; manifest-src 'self'; connect-src 'self'; form-action 'self'; script-src 'self'; img-src 'self' data: cdn.cloudflare.com; frame-src 'self' www.youtube-nocookie.com player.vimeo.com; media-src 'self' data: cdn.cloudflare.com www.youtube-nocookie.com player.vimeo.com; font-src 'self' cdn.cloudflare.com cdn.jsdelivr.net fonts.gstatic.com; style-src 'self' cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;"


### PR DESCRIPTION
This would increase the Mozilla Observatory rating for the After-Dark demo site from 40 to 130: https://observatory.mozilla.org/analyze/zola-after-dark.netlify.app

By default there are only a few allowed external sources:

youtube, vimeo, cloudflare, google(for fonts), jsdelivr

These are the most commonly used external hosts, they should also serve as an example in case anyone needs to add additional hosts.

This is the same netlify Header config I use for the Abridge demo, and all resources there load without issue.

Last month I wrote the code to automate this page: https://github.com/Jieiku/zola-themes-benchmarks/blob/main/README.md (it takes about 30 minutes to run, I am planning to put it on a cron job after I run it a few more times and make sure there are no bugs.)

I am going to try and contribute to many of the themes (especially the overall polished ones) to improve any issues that lighthouse, yellow lab tools, or observatory finds.