### PR TITLE
Add netlify.toml Headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,13 @@
 
 [context.deploy-preview]
     command = "zola build --base-url $DEPLOY_PRIME_URL"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Strict-Transport-Security = "max-age=63072000; includeSubdomains"
+    Content-Security-Policy = "default-src 'none'; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; manifest-src 'self'; connect-src 'self'; form-action 'self'; script-src 'self'; img-src 'self' data: cdn.cloudflare.com; frame-src 'self' www.youtube-nocookie.com player.vimeo.com; media-src 'self' data: cdn.cloudflare.com www.youtube-nocookie.com player.vimeo.com; font-src 'self' cdn.cloudflare.com cdn.jsdelivr.net fonts.gstatic.com; style-src 'self' cdn.cloudflare.com cdn.jsdelivr.net fonts.googleapis.com;"

--- a/sass/_theme.scss
+++ b/sass/_theme.scss
@@ -81,6 +81,9 @@ html {
 .hack pre {
   font-size: 17px;
 }
+.icon {
+  margin-bottom: -3px;
+}
 article [itemprop="description"], article [itemprop="summary"] {
   margin-bottom: 20px;
   margin-top: 20px;

--- a/sass/site.scss
+++ b/sass/site.scss
@@ -1,2 +1,2 @@
-@import "vendor";
-@import "theme";
+@use "vendor";
+@use "theme";

--- a/templates/post_macros.html
+++ b/templates/post_macros.html
@@ -1,12 +1,12 @@
 {% macro meta(page) %}
-    <svg style="margin-bottom:-3px" class="i-clock" viewBox="0 0 32 32"
+    <svg class="icon i-clock" viewBox="0 0 32 32"
          width="16" height="16" fill="none" stroke="currentcolor"
          stroke-linecap="round" stroke-linejoin="round" stroke-width="6.25%">
         <circle cx="16" cy="16" r="14"/>
         <path d="M16 8 L16 16 20 20"/>
     </svg>
     <span>{{ page.reading_time }} minute read</span>
-    <svg style="margin-bottom: -3px" class="i-edit" viewBox="0 0 32 32"
+    <svg class="icon i-edit" viewBox="0 0 32 32"
          width="16" height="16" fill="none" stroke="currentcolor"
          stroke-linecap="round" stroke-linejoin="round" stroke-width="6.25%">
         <path d="M30 7 L25 2 5 22 3 29 10 27 Z M21 6 L26 11 Z M5 22 L10 27 Z"/>


### PR DESCRIPTION
This would increase the Mozilla Observatory rating for the After-Dark demo site from 40 to 130: https://observatory.mozilla.org/analyze/zola-after-dark.netlify.app

By default there are only a few allowed external sources:

youtube, vimeo, cloudflare, google(for fonts), jsdelivr

These are the most commonly used external hosts, they should also serve as an example in case anyone needs to add additional hosts.

This is the same netlify Header config I use for the Abridge demo, and all resources there load without issue.

Last month I wrote the code to automate this page: https://github.com/Jieiku/zola-themes-benchmarks/blob/main/README.md (it takes about 30 minutes to run, I am planning to put it on a cron job after I run it a few more times and make sure there are no bugs.)

I am going to try and contribute to many of the themes (especially the overall polished ones) to improve any issues that lighthouse, yellow lab tools, or observatory finds.

I tested these headers locally, the only thing I had to change was the inline style source for the svg icons, otherwise unsafe-inline would have needed to be included for the style-src CSP.