### PR TITLE
Fix for latest Zola

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
     command = "zola build"
 
 [build.environment]
-    ZOLA_VERSION = "0.16.0"
+    ZOLA_VERSION = "0.17.2"
 
 [context.deploy-preview]
     command = "zola build --base-url $DEPLOY_PRIME_URL"

--- a/theme.toml
+++ b/theme.toml
@@ -2,7 +2,7 @@ name = "after-dark"
 description = "A robust, elegant dark theme"
 license = "MIT"
 homepage = "https://github.com/getzola/after-dark"
-min_version = "0.11.0"
+min_version = "0.17.0"
 demo = "https://zola-after-dark.netlify.app"
 
 [extra]


### PR DESCRIPTION
It seems on my last pull request where I switched from using `@import` to `@use` ( [as per the sass documentation](https://github.com/sass/sass/blob/main/accepted/module-system.md#timeline), `@import` is being phased out)

I inadvertently caused the after-dark theme demo to be a white background for the theme style.

https://zola-after-dark.netlify.app/

I assume this is because the grass dependency in Zola only recently supported `@use`?

Hopefully changing the min Zola Version will fix it.

(I am going to confirm this now by trying with an older version of Zola)

EDIT: I just confirmed this locally, you need Zola 0.17 or later if you want to use `@use` in sass without issue.

This pull request should get the demo looking proper again, sorry about that.