### PR TITLE
Added support for feed_filenames while maintaining compatibility with older versions.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,9 +23,18 @@
   <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 
   {% if config.generate_feed %}
-  <link rel="alternate" type={% if config.feed_filename=="atom.xml" %}"application/atom+xml"{% else
-    %}"application/rss+xml"{% endif %} title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
+  <!-- support feed_filenames -->
+  {% for feed_filename in config.feed_filenames %}
+  <link rel="alternate" type="{% if feed_filename == " atom.xml" %}application/atom+xml{% elif feed_filename=="rss.xml"
+    %}application/rss+xml{% endif %}" title="RSS" href="{{ get_url(path=feed_filename) | safe }}">
+  {% endfor %}
+  {% else %}
+  {% if config.feed_filename %}
+  <link rel="alternate" type="{% if config.feed_filename == " atom.xml" %}application/atom+xml{% else
+    %}application/rss+xml{% endif %}" title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
   {% endif %}
+  {% endif %}
+
 
   {% block css %}
   <link rel="stylesheet" href="{{ get_url(path='site.css', trailing_slash=false) | safe }}">


### PR DESCRIPTION
It appears that Zola now uses an array instead of a single value to name feeds and has changed the name of a variable. [See here.](https://www.getzola.org/documentation/getting-started/configuration/)

This was causing build errors. As I am new to Zola and Tera, this may not be the most elegant solution, but it should maintain backward compatibility and work with newer versions of Zola.

I validated both Atom and RSS feeds using the [W3C Feed Validation Service](https://validator.w3.org/feed/), and everything seems to work as expected.

Please let me know if any changes are required, and thank you for sharing this theme.
