### PR TITLE
Zola 0.19.1 generate_feeds Support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ base_url = "https://getzola.github.io/after-dark/"
 compile_sass = true
 title = "after-dark theme"
 description = "A robust, elegant dark theme"
-generate_feed = true
+generate_feeds = true
 
 taxonomies = [
     {name = "categories", feed = true},

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,10 +22,19 @@
 
   <title>{% block title %}{{ config.title }}{% endblock title %}</title>
 
-  {% if config.generate_feed %}
-  <link rel="alternate" type={% if config.feed_filename=="atom.xml" %}"application/atom+xml"{% else
-    %}"application/rss+xml"{% endif %} title="RSS" href="{{ get_url(path=config.feed_filename) | safe }}">
-  {% endif %}
+  {%- if config.generate_feeds %}
+  {%- for feed in config.feed_filenames %}
+
+  {%- if feed is containing('atom') %}
+  <link rel="alternate" type="application/atom+xml" title="{{ config.title }} Atom Feed" href="{{ get_url(path=feed, trailing_slash=false, lang=lang) | safe }}" />
+  {%- endif %}
+
+  {%- if feed is containing('rss') %}
+  <link rel="alternate" type="application/rss+xml" title="{{ config.title }} RSS Feed" href="{{ get_url(path=feed, trailing_slash=false, lang=lang) | safe }}" />
+  {%- endif %}
+
+  {%- endfor %}
+  {%- endif %}
 
   {% block css %}
   <link rel="stylesheet" href="{{ get_url(path='site.css', trailing_slash=false) | safe }}">

--- a/theme.toml
+++ b/theme.toml
@@ -2,7 +2,7 @@ name = "after-dark"
 description = "A robust, elegant dark theme"
 license = "MIT"
 homepage = "https://github.com/getzola/after-dark"
-min_version = "0.17.0"
+min_version = "0.19.1"
 demo = "https://getzola.github.io/after-dark/"
 
 [extra]


### PR DESCRIPTION
I noticed that I could no longer Zola serve this repository with the latest Zola version.

This adds support for the new generate_feeds syntax.

I also updated the theme.toml to indicate the new minimum Zola version.